### PR TITLE
Fix shortcut conflicts with SublimeAStyleFormatter (using scope selectors)

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,6 @@
 [
-		{ "keys": ["ctrl+alt+f"], "command": "js_format"}
+	{
+		"keys": ["ctrl+alt+f"], "command": "js_format",
+		"context": [{"key": "selector", "operator": "equal", "operand": "source.js,source.json"}]
+	}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,6 @@
 [
-		{ "keys": ["ctrl+alt+f"], "command": "js_format"}
+    {
+        "keys": ["ctrl+alt+f"], "command": "js_format",
+        "context": [{"key": "selector", "operator": "equal", "operand": "source.js,source.json"}]
+    }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,6 @@
 [
-		{ "keys": ["ctrl+alt+f"], "command": "js_format"}
+    {
+        "keys": ["ctrl+alt+f"], "command": "js_format",
+        "context": [{"key": "selector", "operator": "equal", "operand": "source.js,source.json"}]
+    }
 ]


### PR DESCRIPTION
I came across this plugin and found it conflict with the same `Ctrl+Alt+F` key binding with my SublimeAStyleFormatter plugin.

I've added scope selectors to key binding in order to make this plugin works together with SublimeAStyleFormatter by default.
