### PR TITLE
Update js_formatter.py

### DIFF
--- a/js_formatter.py
+++ b/js_formatter.py
@@ -8,7 +8,7 @@ sys.path.append(os.path.join(directory, "jsbeautifier", "unpackers"))
 
 # if you don't explicitly import jsbeautifier.unpackers here things will bomb out,
 # even though we don't use it directly.....
-import jsbeautifier
+import jsbeautifier, jsbeautifier.unpackers
 
 
 s = sublime.load_settings("JsFormat.sublime-settings")


### PR DESCRIPTION
Plugin broke today and console has this printout.  When I paste in the import from the pull request, plugin works:

``` python
Writing file /Users/tfuertes/Library/Application Support/Sublime Text 2/Packages/JsFormat/jsbeautifier/__init__.py with encoding UTF-8
Traceback (most recent call last):
  File "./sublime_plugin.py", line 362, in run_
  File "./js_formatter.py", line 58, in run
  File "./jsbeautifier/__init__.py", line 99, in beautify
    
  File "./jsbeautifier/__init__.py", line 218, in beautify
    
  File "./jsbeautifier/__init__.py", line 255, in unpack
    
ImportError: No module named unpackers
```
