### PR TITLE
Do not automatically format JSP files.

### DIFF
--- a/js_formatter.py
+++ b/js_formatter.py
@@ -36,7 +36,7 @@ class PreSaveFormatListner(sublime_plugin.EventListener):
 		if(syntaxPath != None):
 			syntax = os.path.splitext(syntaxPath)[0].split('/')[-1].lower()
 
-		formatFile = "js" in ext or "json" in ext or "javascript" in syntax or "json" in syntax
+		formatFile = ("js" in ext and "jsp" not in ext) or "json" in ext or "javascript" in syntax or "json" in syntax
 
 		if(s.get("format_on_save") == True and formatFile):
 			view.run_command("js_format")


### PR DESCRIPTION
Currently, any file with "js" in the extension is automatically formatted when "format_on_save" is true.  However, this horribly mangles JSP files to the point where they will no longer compile.  This should remove JSPs from the file types which are formatted automatically.
