### PR TITLE
add options to apply formatting by file extension, file syntax, or both

### DIFF
--- a/JsFormat.sublime-settings
+++ b/JsFormat.sublime-settings
@@ -13,5 +13,8 @@
 	"break_chained_methods": false,
 
 	// jsformat options
-	"format_on_save": false
+	"format_on_save": false,
+	"format_by_extension_syntax": "both",
+	"format_file_extension": ["js", "json"],
+	"format_file_syntax": ["javascript", "json"]
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ In addition, the following settings are available in JsFormat/JsFormat.sublime-s
 * "unescape_strings": false,
 * "break_chained_methods": false*
 * "format_on_save": false
+* "format_by_extension_syntax": "both"  (both, extension, syntax)
+* "format_file_extension": ["js", "json"]
+* "format_file_syntax": ["javascript", "json"]
 
 I had temporary lapse of judgement a while back and merged a pull request that modified jsbeautifier. As a result, the functionality that
 was added from that pull request has been lost; ```"ensure_space_before_linestarters"``` is no longer supported.

--- a/js_formatter.py
+++ b/js_formatter.py
@@ -50,13 +50,23 @@ def is_js_buffer(view):
 	syntaxPath = vSettings.get('syntax')
 	syntax = ""
 	ext = ""
+	syntaxOrExtension = s.get("format_by_extension_syntax")
+	syntaxList = s.get("format_file_syntax")
+	extensionList = s.get("format_file_extension")
+	result = False
 
-	if (fName != None): # file exists, pull syntax type from extension
-		ext = os.path.splitext(fName)[1][1:]
-	if(syntaxPath != None):
-		syntax = os.path.splitext(syntaxPath)[0].split('/')[-1].lower()
+	if (syntaxOrExtension in ['both', 'extension']):
+		if (fName != None): # file exists, pull syntax type from extension
+			ext = os.path.splitext(fName)[1][1:]
+			if (ext in extensionList):
+				result = True
+	if (syntaxOrExtension in ['both', 'syntax']):
+		if(syntaxPath != None):
+			syntax = os.path.splitext(syntaxPath)[0].split('/')[-1].lower()
+			if (syntax in syntaxList):
+				result = True;
 
-	return ext in ['js', 'json'] or "javascript" in syntax or "json" in syntax
+	return result
 
 class PreSaveFormatListner(sublime_plugin.EventListener):
 	"""Event listener to run JsFormat during the presave event"""


### PR DESCRIPTION
I saw issue 69 (https://github.com/jdc0589/JsFormat/issues/69) and it related to something I was trying to figure out.  I like the formatting that jsbeautify does for javascript, but not for JSON.  I just find it expands things too much.  So, I wanted to be able to continue using jsFormat for javascript files, but not for JSON files.

Since issue 69 also wanted to exclude js.erb files from being formatted, I thought a good solution would be to allow the user to configure jsFormat to format files based on file extension, file syntax, or both.  This way, you can enable/disable jsFormat for a file extension regardless of the content of the file, or you can configure it to format based on file syntax regardless of the file extension.  The defaults leave the functionality the same as before the changes.

Let me know what you think about these changes.  Any recommendations?  Optimizations?
