### PR TITLE
When "format_on_save" is enabled, first check if there are some error

### DIFF
--- a/js_formatter.py
+++ b/js_formatter.py
@@ -49,8 +49,13 @@ class PreSaveFormatListner(sublime_plugin.EventListener):
 	"""Event listener to run JsFormat during the presave event"""
 	def on_pre_save(self, view):
 		if(s.get("format_on_save") == True and jsf_activation.is_js_buffer(view)):
+			# only auto-format on save if there are no "lint errors"
+			# here are some named regions from sublimelint see https://github.com/lunixbochs/sublimelint/tree/st3
+			lints_regions = ['lint-keyword-underline', 'lint-keyword-outline']
+			for linter in lints_regions:
+				if len(view.get_regions(linter)):
+					return
 			view.run_command("js_format")
-
 
 class JsFormatCommand(sublime_plugin.TextCommand):
 	def run(self, edit):


### PR DESCRIPTION
As described somewhere else https://github.com/jdc0589/JsFormat/issues/112 Is problematic to auto-format automatically on save.

This requests avoids auto-format on save if there are some lint error. Currently it only checks for sublimelint, it does not check for errors reported by SublimeLinter3 which I do not use, and I don't know which regions adds. Would be easy to append to the list of regions if someone knows.
