### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The default key binding is "ctrl+alt+f"
 Unfortunately there are other plugins that use "ctrl + alt + f", this is a hard problem to solve. If JsFormat works
 OK via the command palette but does nothing when you use the "ctrl + alt + f" shortcut, you have two options:
 
-1. Add ```{ "keys": ["ctrl+alt+f"], "command": "js_format"}``` to your user keybindings file. This will override anything specified by a plugin.
+1. Add ```{ "keys": ["ctrl+alt+f"], "command": "js_format", "context": [{"key": "selector", "operator": "equal", "operand": "source.javascript"}] }``` to your user keybindings file. This will override anything specified by a plugin.
 2. Find the offending plugin, and change the shortcut in its sublime-keymap file (will revert on updates)
 
 


### PR DESCRIPTION
This will limit the action to to only work on js type files. 

I found that if you don't limit the binding to js files it will mess up your HTML. It's also useful for allowing you to bind another formatter to the same key-binding for other file types (IE HTML).
