### PR TITLE
When "format_on_save" is true, and I don't want it for current file...

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,5 +1,5 @@
 [
-    { 
+    {
     	"id": "jsformatmenu",
     	"command": "js_format",
     	"caption": "JsFormat"

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,5 +1,14 @@
 [
     {
+        "caption": "File",
+        "mnemonic": "F",
+        "id": "file",
+        "children":
+        [
+            { "command": "js_format_pre_save_no_format", "caption": "Save With No JS Reformatting"  }
+        ]
+    },
+    {
         "caption": "Preferences",
         "mnemonic": "n",
         "id": "preferences",


### PR DESCRIPTION
Hi there! happy new year, 

If you use "format_on_save", many times you don't want to touch the current formatting of the file.

This adds a new menu entry in the Main menubar -> File -> "Save With No JS Reformatting"

Kind regards, 
